### PR TITLE
Added '/swapfile' to rsync exclude

### DIFF
--- a/image-backup-ubuntu
+++ b/image-backup-ubuntu
@@ -89,7 +89,7 @@ backup()
   sync
   rsync -aDH --partial --numeric-ids --delete --force --exclude "${MNTPATH}" --exclude '/dev' --exclude '/lost+found' --exclude '/media' --exclude '/mnt' \
 --exclude '/proc' --exclude '/run' --exclude '/sys' --exclude '/tmp' --exclude '/srv' --exclude '/var/swap' --exclude '/etc/udev/rules.d/70-persistent-net.rules' \
---exclude '/var/lib/asterisk/astdb.sqlite3-journal' "${OPTIONS[@]}" / "${MNTPATH}/"
+--exclude '/var/lib/asterisk/astdb.sqlite3-journal' --exclude '/swapfile' "${OPTIONS[@]}" / "${MNTPATH}/"
   if [[ $? -ne 0 && $? -ne 24 ]]; then
     errexit "Unable to create backup"
   fi


### PR DESCRIPTION
Some systems use /swapfile either exclusively or in addition to a swap partition. Needs to be added to excludes.